### PR TITLE
Allow home-manager without global configuration

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -264,7 +264,7 @@ toplevel @ {
     };
   };
 
-  useHomeManager = cfg.homeModules != [];
+  useHomeManager = cfg.homeModules != [] || cfg.homeConfigurations != {};
 
   makeSystemConfig = hostName: hostConfig:
     withSystem hostConfig.system ({liteConfigPkgs, ...}: let


### PR DESCRIPTION
This allows per-machine home manager configurations to be created easily without needing to include a dummy global home manager module which enables the creation of the configurations in lite-config.homeConfigurations.

See personal config and commit that shows what this change enables here: https://github.com/gigamonster256/nix-config/commit/165acb4294ed75150da972ce1693d904f8146e9e